### PR TITLE
add rate limiter using memcache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,15 @@ COPY mind_matter_api mind_matter_api
 
 COPY .env.example .env
 
+# ================================= DEVELOPMENT ================================
+FROM builder AS development
+RUN pip install --no-cache -r requirements/dev.txt
+EXPOSE 2992
+EXPOSE 5000
+
+CMD [ "flask", "run", "--host=0.0.0.0"]
+
+
 # ================================= PRODUCTION =================================
 FROM python:${INSTALL_PYTHON_VERSION}-slim-bullseye as production
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,12 @@ services:
     ports:
       - "5000:5000"
       - "2992:2992"
+    environment:
+      CACHE_MEMCACHED_SERVERS: memcached:11211
+      FLASK_ENV: development
+      FLASK_DEBUG: 1
+    depends_on:
+      - memcached
     <<: *default_volumes
 
   mind-matter-flask-prod:
@@ -32,6 +38,9 @@ services:
       FLASK_DEBUG: 0
       LOG_LEVEL: info
       GUNICORN_WORKERS: 4
+      CACHE_MEMCACHED_SERVERS: memcached:11211
+    depends_on:
+      - memcached
     <<: *default_volumes
 
   mind-matter-manage:
@@ -48,3 +57,16 @@ services:
     stdin_open: true
     tty: true
     <<: *default_volumes
+
+  memcached:
+    image: memcached:alpine
+    ports:
+      - "11211:11211"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "echo", "version", "|", "nc", "localhost", "11211"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,10 @@ services:
       - "5000:5000"
       - "2992:2992"
     environment:
-      CACHE_MEMCACHED_SERVERS: memcached:11211
+
       FLASK_ENV: development
       FLASK_DEBUG: 1
-    depends_on:
-      - memcached
+
     <<: *default_volumes
 
   mind-matter-flask-prod:
@@ -38,9 +37,6 @@ services:
       FLASK_DEBUG: 0
       LOG_LEVEL: info
       GUNICORN_WORKERS: 4
-      CACHE_MEMCACHED_SERVERS: memcached:11211
-    depends_on:
-      - memcached
     <<: *default_volumes
 
   mind-matter-manage:
@@ -57,16 +53,3 @@ services:
     stdin_open: true
     tty: true
     <<: *default_volumes
-
-  memcached:
-    image: memcached:alpine
-    ports:
-      - "11211:11211"
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "echo", "version", "|", "nc", "localhost", "11211"]
-      interval: 5s
-      timeout: 2s
-      retries: 5
-
-

--- a/mind_matter_api/app.py
+++ b/mind_matter_api/app.py
@@ -33,16 +33,12 @@ def create_app(config_object="mind_matter_api.settings"):
     :param config_object: The configuration object to use.
     """
     app = Flask(__name__, root_path=os.path.dirname(os.path.abspath(__file__)))
-    CORS(app, resources={r"/*": {"origins": "*"}}, supports_credentials=True)  # <
+    CORS(app, resources={r"/*": {"origins": "*"}}, supports_credentials=False)  # <
     
     # Rate limiter using flask-caching (memcached )
     
     logger = logging.getLogger(__name__)
-    if not hasattr(cache, '_cache'):  # or check if cache.cache is None
-        cache.init_app(app)
 
-
-    app.before_request(rate_limit_middleware(limit=5, window=60))
     # Load configuration
     app.config.from_object(config_object)
     app.config["SQLALCHEMY_RECORD_QUERIES"] = True
@@ -56,6 +52,11 @@ def create_app(config_object="mind_matter_api.settings"):
     register_routes(app)
     configure_logger(app)
 
+    app.before_request(rate_limit_middleware(
+        limit=5,
+        window=60,
+        exclude_paths=["/health"]
+    ))
 
     # Swagger UI
     Swagger(

--- a/mind_matter_api/middleware/rate_limit.py
+++ b/mind_matter_api/middleware/rate_limit.py
@@ -1,8 +1,18 @@
 import time
 from flask import request, jsonify
 from mind_matter_api.extensions import cache   
-def rate_limit_middleware(limit: int, window: int):
+
+
+def rate_limit_middleware(limit: int, window: int, exclude_paths=None, exclude_methods=None):
+    exclude_paths = exclude_paths or []
+    exclude_methods = exclude_methods or []
+
     def middleware():
+        cache.set("foo", "bar")
+        print(cache.get("foo"))  
+        if request.path in exclude_paths or request.method in exclude_methods:
+            return 
+
         ip = request.remote_addr or "global"
         key = f"rate-limit:{ip}:{request.endpoint}"
         now = time.time()
@@ -19,4 +29,5 @@ def rate_limit_middleware(limit: int, window: int):
                 cache.set(key, (1, now))
         else:
             cache.set(key, (1, now))
+
     return middleware

--- a/mind_matter_api/middleware/rate_limit.py
+++ b/mind_matter_api/middleware/rate_limit.py
@@ -1,6 +1,28 @@
 import time
 from flask import request, jsonify
-from mind_matter_api.extensions import cache   
+from mind_matter_api.extensions import cache
+from mind_matter_api.utils.auth import decode_auth_token  # assume this exists
+
+def get_rate_limit_identity():
+    # 1. Check for Device ID header (mobile apps)
+    device_id = request.headers.get("X-Device-ID")
+    if device_id:
+        return f"device:{device_id}"
+
+    # 2. Check for authenticated user (e.g. JWT bearer)
+    auth_header = request.headers.get("Authorization")
+    if auth_header and " " in auth_header:
+        token_type, token = auth_header.split(" ", 1)
+        if token_type.lower() == "bearer":
+            try:
+                user_id = decode_auth_token(token)
+                if user_id:
+                    return f"user:{user_id}"
+            except Exception:
+                pass
+
+    # 3. Fallback to IP address
+    return f"ip:{request.remote_addr or 'unknown'}"
 
 
 def rate_limit_middleware(limit: int, window: int, exclude_paths=None, exclude_methods=None):
@@ -8,13 +30,11 @@ def rate_limit_middleware(limit: int, window: int, exclude_paths=None, exclude_m
     exclude_methods = exclude_methods or []
 
     def middleware():
-        cache.set("foo", "bar")
-        print(cache.get("foo"))  
         if request.path in exclude_paths or request.method in exclude_methods:
-            return 
+            return
 
-        ip = request.remote_addr or "global"
-        key = f"rate-limit:{ip}:{request.endpoint}"
+        identity = get_rate_limit_identity()
+        key = f"rate-limit:{identity}:{request.endpoint}"
         now = time.time()
 
         record = cache.get(key)
@@ -23,11 +43,17 @@ def rate_limit_middleware(limit: int, window: int, exclude_paths=None, exclude_m
             count, first_time = record
             if now - first_time < window:
                 if count >= limit:
-                    return jsonify({"error": "Rate limit exceeded"}), 429
-                cache.set(key, (count + 1, first_time))
+                    retry_after = int(window - (now - first_time) + 1)
+                    response = jsonify({
+                        "error": "Rate limit exceeded",
+                        "retry_after_seconds": retry_after
+                    })
+                    response.headers["Retry-After"] = str(retry_after)
+                    return response, 429
+                cache.set(key, (count + 1, first_time), timeout=window * 2)
             else:
-                cache.set(key, (1, now))
+                cache.set(key, (1, now), timeout=window * 2)
         else:
-            cache.set(key, (1, now))
+            cache.set(key, (1, now), timeout=window * 2)
 
     return middleware

--- a/mind_matter_api/middleware/rate_limit.py
+++ b/mind_matter_api/middleware/rate_limit.py
@@ -1,0 +1,22 @@
+import time
+from flask import request, jsonify
+from mind_matter_api.extensions import cache   
+def rate_limit_middleware(limit: int, window: int):
+    def middleware():
+        ip = request.remote_addr or "global"
+        key = f"rate-limit:{ip}:{request.endpoint}"
+        now = time.time()
+
+        record = cache.get(key)
+
+        if record:
+            count, first_time = record
+            if now - first_time < window:
+                if count >= limit:
+                    return jsonify({"error": "Rate limit exceeded"}), 429
+                cache.set(key, (count + 1, first_time))
+            else:
+                cache.set(key, (1, now))
+        else:
+            cache.set(key, (1, now))
+    return middleware

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,4 +19,4 @@ pep8-naming==0.14.1
 
 Flask-Cors==5.0.0
 
-pyjwt==2.10.1
+

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -17,7 +17,7 @@ Flask-Migrate==4.0.7  # Handles database migrations with Alembic
 
 # === Authentication and User Management ===
 Flask-Login==0.6.3  # User session management for Flask
-PyJWT==2.8.0  # JSON Web Token implementation
+pyjwt==2.10.1
 
 # === Deployment ===
 gevent==24.11.1  # Asynchronous networking library for concurrent requests
@@ -25,8 +25,6 @@ gunicorn>=19.9.0  # WSGI HTTP server for deploying Python applications
 supervisor==4.2.5  # Process manager for running background services
 
 
-# === Caching ===
-Flask-Caching>=2.0.2  # Adds caching support for better performance
 
 # === Environment Variable Management ===
 environs==11.2.1  # Simplifies parsing and managing environment variables
@@ -52,4 +50,8 @@ pytest-cov==6.0.0
 WebTest==3.0.2
 flasgger
 
+
 Flask-Mail
+
+# === Rate Limiting ===
+Flask-Caching==2.3.1


### PR DESCRIPTION
### Description

Brief summary of the changes and any relevant context (design doc, screenshots of bugs...).
Add rate-limit middleware, a docker stage for memcache using flask caching (https://flask-caching.readthedocs.io/en/latest/)
#16 
Fixes # (issue)

### Changes

- **Feature**: Describe new features or changes.
- **Bugfix**: Outline any bug fixes.
- **Refactor**: Note any code refactoring.

### Testing

Describe tests run to verify changes. If manual testing has been done, provide instructions to reproduce.

- [ ] Unit tests
- [ ] Manual testing

### Checklist:

- [ ] Added tests for new features or bug fixes
- [ ] (For the final review) I have refactored my code :)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced rate limiting to the API, restricting clients to 5 requests per 60 seconds per endpoint.
- **Chores**
  - Enhanced Docker and Docker Compose configurations with a dedicated development environment and debug settings.
  - Updated and reorganized development and production dependencies for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->